### PR TITLE
defaults.t: Android needs some %ENV variables to remain

### DIFF
--- a/t/defaults.t
+++ b/t/defaults.t
@@ -4,6 +4,7 @@ use warnings;
 
 use Test::More 'no_plan';
 
+use Config;
 use File::Spec;
 
 my $class = 'Module::Release';
@@ -17,10 +18,20 @@ BEGIN {
 	require $file;
 	}
 	
+
+my %required_env;
+
+if ( $^O eq 'android' ) {
+    my $ldlibpth             = $Config{ldlibpthname};
+    $required_env{$ldlibpth} = $ENV{$ldlibpth};
+    $required_env{PATH}      = $ENV{PATH};
+}
+
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Create object with no parameters, clean environment
 {
-local %ENV; # don't react to overall setup
+
+local %ENV = %required_env; # don't react to overall setup
 my $method = 'debug';
 
 my $release = $class->new;
@@ -33,7 +44,7 @@ ok( ! $release->$method(), "debug starts off" );
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Create object with no parameters, RELEASE_DEBUG = 1
 {
-local %ENV; # don't react to overall setup
+local %ENV = %required_env; # don't react to overall setup
 my $var = "RELEASE_DEBUG";
 
 $ENV{RELEASE_DEBUG} = 1;
@@ -50,7 +61,7 @@ is( $release->$method(), $ENV{$var},
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Create object with no parameters, RELEASE_DEBUG = 0
 {
-local %ENV; # don't react to overall setup
+local %ENV = %required_env; # don't react to overall setup
 my $var = "RELEASE_DEBUG";
 
 $ENV{RELEASE_DEBUG} = 0;


### PR DESCRIPTION
Technically this isn't Android specific, but android
requires it because of two tangentially related
issues:

```
* $^X on android currently returns 'perl',
  rather than a full path. So $ENV{PATH} is needed.
* perls built with -Duseshrplib need to be able to
  find their libperl.so, but Android's linker will
  only look in /system/lib, which is a read-only
  filesystem and thus unlikely to have the
  user-supplied libperl. This means that
  $ENV{LD_LIBRARY_PATH} is needed.
```
