### PR TITLE
Module/Release/Prereq.pm - use Test::Prereq::Build when appropriate

### DIFF
--- a/lib/Module/Release.pm
+++ b/lib/Module/Release.pm
@@ -101,6 +101,10 @@ The name of the file to run as F<Makefile.PL>.  The default is
 C<"Makefile.PL">, but you can set it to C<"Build.PL"> to use a
 C<Module::Build>-based system.
 
+If this is set to C<"Build.PL">, this his will also cause
+C<Module::Build::Prereqs> to use C<Test::Prereqs::Build> instead of
+C<Test::Prereqs>.
+
 =item makefile
 
 The name of the file created by C<makefile_PL> above.  The default is

--- a/lib/Module/Release/Prereq.pm
+++ b/lib/Module/Release/Prereq.pm
@@ -34,19 +34,29 @@ It looks in local_name to get the name of the distribution file.
 
 =cut
 
+
+my %Prereq_modules = (
+	'' => 'Test::Prereq',
+	'Makefile.PL' => 'Test::Prereq',
+	'Build.PL' => 'Test::Prereq::Build',
+);
+
 sub check_prereqs
 	{
-	eval "require Test::Prereq; 1 " or
-		$_[0]->_die( "You need Test::Prereq to check prereqs" );
+	my $prereqs_type = $_[0]->config->makefile_PL;
+	my $test_prereqs = $Prereq_modules{$prereqs_type} || 'Test::Prereq';
 
-	$_[0]->_print( "Checking prereqs... " );
+	eval "require $test_prereqs; 1 " or
+		$_[0]->_die( "You need $test_prereqs to check prereqs" );
+
+	$_[0]->_print( "Checking prereqs with $test_prereqs... " );
 
 	my $perl = $_[0]->{perl};
 
 	my @ignore = $_[0]->_get_prereq_ignore_list;
 
 	my $messages = $_[0]->run(
-		qq|$perl -MTest::Prereq -e "prereq_ok( undef, undef, [ qw(@ignore) ] )"|
+		qq|$perl -M$test_prereqs -e "prereq_ok( undef, undef, [ qw(@ignore) ] )"|
 		);
 
 	$_[0]->_die( "Prereqs had a problem:\n$messages\n" )


### PR DESCRIPTION
Checks the value of makefile_PL config setting to determine this.

Without this, the prereqs check fails on my Build.PL based distro.
