### PR TITLE
Use three-arg form of open()

### DIFF
--- a/lib/Module/Release.pm
+++ b/lib/Module/Release.pm
@@ -1196,7 +1196,7 @@ you may well want to overload it.
 =cut
 
 sub get_readme {
-	open my $fh, '<README' or return '';
+	open my $fh, '<', 'README' or return '';
 	my $data = do {
 		local $/;
 		<$fh>;
@@ -1249,7 +1249,7 @@ sub run {
 	$self->_debug( "$command\n" );
 	$self->_die( "Didn't get a command!" ) unless defined $command;
 
-	open my($fh), "$command |" or $self->_die( "Could not open command [$command]: $!" );
+	open my($fh), "-|", "$command" or $self->_die( "Could not open command [$command]: $!" );
 	$fh->autoflush;
 
 	my $output = '';


### PR DESCRIPTION
I found a couple of instances of the older two-arg form of `open()` being used and have updated the code to use the three-arg form here.  The tests still pass and Travis seems happy with the change as well.

This PR is submitted in the hope that it is useful.  If you have any questions or comments concerning it, please let me know and I can update and resubmit as necessary.