### PR TITLE
Add missing strictures

### DIFF
--- a/hack/mojo.pl
+++ b/hack/mojo.pl
@@ -1,3 +1,5 @@
+use strict;
+use warnings;
 use Module::Release;
 
 my $release = Module::Release->new;

--- a/t/compile.t
+++ b/t/compile.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More tests => 2;
 
 my $file = 'blib/script/release';

--- a/t/load.t
+++ b/t/load.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 my @classes = qw(
 		Module::Release
 		Module::Release::Kwalitee

--- a/t/no_releaserc_can_die.t
+++ b/t/no_releaserc_can_die.t
@@ -9,6 +9,9 @@ Reported by Sagar Shah.
 
 =cut
 
+use strict;
+use warnings;
+
 use Test::More;
 
 BEGIN {

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,3 +1,5 @@
+use strict;
+use warnings;
 use Test::More;
 eval "use Test::Pod 1.00";
 plan skip_all => "Test::Pod 1.00 required for testing POD" if $@;

--- a/t/pod_coverage.t
+++ b/t/pod_coverage.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More;
 eval "use Test::Pod::Coverage 1.00";
 

--- a/xt/changes.t
+++ b/xt/changes.t
@@ -1,3 +1,5 @@
+use strict;
+use warnings;
 use Test::More;
 eval 'use Test::CPAN::Changes';
 plan skip_all => 'Test::CPAN::Changes required for this test' if $@;


### PR DESCRIPTION
Perlcritic noticed that strictures were missing in some files.  The missing strictures have been added in these commits, which I've separated according to directory just in case you wish to cherry pick the changes.

This PR is submitted in the hope that it is useful.  If you have any questions or comments about it, please don't hesitate to let me know, and if you wish for anything to be changed I'll update the PR as appropriate and resubmit.