### PR TITLE
Restrict loop variable scope to loop

### DIFF
--- a/t/dist_version.t
+++ b/t/dist_version.t
@@ -102,8 +102,7 @@ subtest 'three part versions' => sub {
         ['Foo'        => '', "...with no suffix"],
     );
 
-    my $case;
-    foreach $case (@cases) {
+    foreach my $case (@cases) {
         my ($dist_name, $expected_version, $descr) = @$case;
         my $mock = bless { remote_file => $dist_name }, $class;
         my $got_version = $mock->dist_version;


### PR DESCRIPTION
Perlcritic noticed that the loop variable changed here wasn't scoped to
the loop it refers to.  This change fixes the variable's scope.