### PR TITLE
Replace :utf8 with :encoding(UTF-8) for strict I/O validation

### DIFF
--- a/lib/Module/Release.pm
+++ b/lib/Module/Release.pm
@@ -1213,7 +1213,7 @@ you may well want to overload it.
 =cut
 
 sub get_changes {
-	open my $fh, '<:utf8', 'Changes' or return '';
+	open my $fh, '<:encoding(UTF-8)', 'Changes' or return '';
 
 	my $data = <$fh>;  # get first line
 

--- a/script/release
+++ b/script/release
@@ -522,8 +522,8 @@ unless( $release->debug or $opts{C} ) {
 
 	rename $changes, $bak or die "Could not backup $changes. $!\n";
 
-	open my $in, '<:utf8', $bak or die "Could not read old $changes file! $!\n";
-	open my $out, ">:utf8", $changes;
+	open my $in, '<:encoding(UTF-8)', $bak or die "Could not read old $changes file! $!\n";
+	open my $out, ">:encoding(UTF-8)", $changes;
 
 	while( <$in> ) {
 		print $out $_;

--- a/t/lib/setup_common.pl
+++ b/t/lib/setup_common.pl
@@ -24,7 +24,7 @@ subtest test_dir => sub {
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Create empty configuration file
 subtest create_empty_conf => sub {
-	my $rc = open my $fh, '>:utf8', conf_file();
+	my $rc = open my $fh, '>:encoding(UTF-8)', conf_file();
 	my $error = $! unless $rc;
 
 	ok( $rc, "Opened empty " . conf_file() );


### PR DESCRIPTION
Perlcritic mentions that using `:encoding(UTF-8)` is better practice than simply using `:utf8` in I/O operations.  This PR fixes the issue and hence removes the perlcritic warning.

This PR is submitted in the hope that it is useful. If you have any questions or comments about it, please don't hesitate to let me know, and if you wish for anything to be changed I'll update the PR as appropriate and resubmit.