### PR TITLE
Remove unused variable

### DIFF
--- a/t/lib/setup_common.pl
+++ b/t/lib/setup_common.pl
@@ -25,7 +25,6 @@ subtest test_dir => sub {
 # Create empty configuration file
 subtest create_empty_conf => sub {
 	my $rc = open my $fh, '>:utf8', conf_file();
-	my $error = $! unless $rc;
 
 	ok( $rc, "Opened empty " . conf_file() );
 	diag( "Error creating " . conf_file() . "! $!" ) unless $rc;


### PR DESCRIPTION
Perlcritic had actually noticed that a variable was being assigned to within a conditional statement, however looking at the code I noticed that the `$error` variable was never being used, hence this PR.  If you actually intended for this line of code to perform some purpose other than that done by the `ok()` and `diag()` calls later in the code then I'd be really interested in the reason why the code with the `$error` variable was included; I wouldn't expect you to add such code unless it was necessary for some reason, and I have the vague feeling I'm missing something subtle here.