### PR TITLE
Purge trailing whitespace

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,7 +15,7 @@ Revision history for Perl module Module::Release
 	* Catch up with latest Test::More and perl behavior
 
 2.122_01 2016-11-16T01:15:00Z
-	* Try harder to find out what's going on with Dan Collins's 
+	* Try harder to find out what's going on with Dan Collins's
 	testers setup.
 
 2.122 2016-03-04T23:38:14Z

--- a/hack/git.pl
+++ b/hack/git.pl
@@ -18,7 +18,7 @@ print $git_update, "\n-------------\n";
 $git_update =~ s/^#\s//gm; # one space
 print $git_update, "\n-------------\n";
 
-$git_update =~ s/^\s*\(.*?\)[\r\n]+//mg;	
+$git_update =~ s/^\s*\(.*?\)[\r\n]+//mg;
 print $git_update, "\n-------------\n";
 
 
@@ -27,18 +27,18 @@ my(undef, %bits ) = split /^(\w.*):[\r\n]+/m, $git_update;
 
 foreach my $key ( keys %bits )
 	{
-	my @lines = 
-		map { my $x = $_; $x =~ s/^\s+//; $x =~ s/\s+$//; $x } 
+	my @lines =
+		map { my $x = $_; $x =~ s/^\s+//; $x =~ s/\s+$//; $x }
 		split /[\r\n]+/, $bits{ $key };
-	
+
 	$" = "\n\t";
 	print "$key lines:\n\t@lines\n";
-	
+
 	$bits{$key} = [ @lines ];
 	}
 
 print Dumper( \%bits );
-	
+
 __DATA__
 # On branch master
 # Changes to be committed:

--- a/hack/mojo.pl
+++ b/hack/mojo.pl
@@ -7,4 +7,4 @@ $release->config->set( cpan_user => 'BDFOY' );
 $release->config->set( cpan_pass => 'R$45tear' );
 
 $release->load_mixin( 'Module::Release::WebUpload::Mojo' );
-$release->web_upload; 
+$release->web_upload;

--- a/script/release
+++ b/script/release
@@ -31,7 +31,7 @@ release - give your Perl distros to the world
 
 	# set $ENV{AUTOMATED_TESTING} to a true value
 	release -a
-	
+
 
 =head1 DESCRIPTION
 
@@ -154,7 +154,7 @@ release does not test the perls in any particular order.
 
 =item automated_testing
 
-Set C<automated_testing> to the value you want for the 
+Set C<automated_testing> to the value you want for the
 $ENV{AUTOMATED_TESTING} setting. By default this is 0, so
 testing is started in interactive mode.
 
@@ -383,19 +383,19 @@ my $skip_prereqs = $opts{p} || $release->config->skip_prereqs;
 my $skip_dist    = $opts{D} || $release->config->skip_dist;
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# Set automated testing from command line, config, environment, or default 
+# Set automated testing from command line, config, environment, or default
 {
 no warnings 'uninitialized';
 
-$ENV{AUTOMATED_TESTING} = ( 
-	grep { defined } ( 
-		$opts{a}, $release->config->automated_testing, 
-		$ENV{AUTOMATED_TESTING}, 0 ) 
+$ENV{AUTOMATED_TESTING} = (
+	grep { defined } (
+		$opts{a}, $release->config->automated_testing,
+		$ENV{AUTOMATED_TESTING}, 0 )
 	)[0];
 $release->_debug( "Automated testing is $ENV{AUTOMATED_TESTING}; -a was $opts{a};" .
 	" automated_testing was " . $release->config->automated_testing . ";\n" );
-}	
-	
+}
+
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # test with a bunch of perls
 unless( $opts{T} ) {
@@ -416,7 +416,7 @@ unless( $opts{T} ) {
 		else {
 			$opts{t} or $release->_print( "Skipping prereq checks. Shame on you!\n" );
 			}
-		
+
 		unless( $skip_dist ) {
 			$release->dist;
 			$release->disttest;
@@ -570,7 +570,7 @@ while( $release->should_upload_to_pause ) {
 	$release->_print("Now uploading to PAUSE\n" );
 	$release->_print("============Uploading to PAUSE\n");
 	last if $release->debug;
-	
+
 	$release->web_upload;
 
 	last;

--- a/t/compile.t
+++ b/t/compile.t
@@ -3,8 +3,8 @@ use Test::More tests => 2;
 my $file = 'blib/script/release';
 
 use_ok( 'Module::Release' );
-	
+
 my $output = `$^X -Mblib -c $file 2>&1`;
-			
+
 like( $output, qr/syntax OK$/, 'script compiles' );
-           
+

--- a/t/pod_coverage.t
+++ b/t/pod_coverage.t
@@ -2,7 +2,7 @@ use Test::More;
 eval "use Test::Pod::Coverage 1.00";
 
 plan $@ ? ( skip_all => "Test::Pod::Coverage 1.00 required for testing POD" )
-	: 
+	:
 	( tests => 1 )
 	;
 


### PR DESCRIPTION
Trailing whitespace is seen in some projects as bad practice (e.g. the Linux kernel) and is hence explicitly forbidden; other projects see its removal as plain nit-picking. This PR is submitted in the hope that it is helpful, however if you don't see any need to remove such whitespace I'm happy if you close the PR as unmerged.