### PR TITLE
Update copyright year in release script

### DIFF
--- a/script/release
+++ b/script/release
@@ -254,7 +254,7 @@ brian d foy, C<< <bdfoy@cpan.org> >>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright © 2002-2015, brian d foy <bdfoy@cpan.org>. All rights reserved.
+Copyright © 2002-2017, brian d foy <bdfoy@cpan.org>. All rights reserved.
 
 You may use this software under the same terms as Perl itself.
 


### PR DESCRIPTION
I noticed that the copyright year mentioned in the release script wasn't consistent with the copyright year mentioned in other files.  This updates the information so that all files now contain consistent copyright information.