### PR TITLE
Fix GitHub capitalisation

### DIFF
--- a/lib/Module/Release.pm
+++ b/lib/Module/Release.pm
@@ -1375,7 +1375,7 @@ H.Merijn Brand has contributed many patches and features.
 
 =head1 SOURCE AVAILABILITY
 
-This source is in Github:
+This source is in GitHub
 
 	https://github.com/briandfoy/module-release
 

--- a/lib/Module/Release/FTP.pm
+++ b/lib/Module/Release/FTP.pm
@@ -194,7 +194,7 @@ L<Module::Release>
 
 =head1 SOURCE AVAILABILITY
 
-This source is in Github:
+This source is in GitHub
 
 	https://github.com/briandfoy/module-release
 

--- a/lib/Module/Release/Kwalitee.pm
+++ b/lib/Module/Release/Kwalitee.pm
@@ -82,7 +82,7 @@ L<Module::Release>
 
 =head1 SOURCE AVAILABILITY
 
-This source is in Github:
+This source is in GitHub
 
 	https://github.com/briandfoy/module-release
 

--- a/lib/Module/Release/MANIFEST.pm
+++ b/lib/Module/Release/MANIFEST.pm
@@ -67,7 +67,7 @@ L<Module::Release>
 
 =head1 SOURCE AVAILABILITY
 
-This source is in Github:
+This source is in GitHub
 
 	https://github.com/briandfoy/module-release
 

--- a/lib/Module/Release/PAUSE.pm
+++ b/lib/Module/Release/PAUSE.pm
@@ -37,7 +37,7 @@ L<Module::Release>
 
 =head1 SOURCE AVAILABILITY
 
-This source is in Github:
+This source is in GitHub
 
 	https://github.com/briandfoy/module-release
 

--- a/lib/Module/Release/Prereq.pm
+++ b/lib/Module/Release/Prereq.pm
@@ -78,7 +78,7 @@ L<Module::Release>
 
 =head1 SOURCE AVAILABILITY
 
-This source is in Github:
+This source is in GitHub
 
 	https://github.com/briandfoy/module-release
 

--- a/lib/Module/Release/SVN.pm
+++ b/lib/Module/Release/SVN.pm
@@ -247,7 +247,7 @@ L<Module::Release>
 
 =head1 SOURCE AVAILABILITY
 
-This source is in Github:
+This source is in GitHub
 
 	https://github.com/briandfoy/module-release
 

--- a/lib/Module/Release/WebUpload/Mojo.pm
+++ b/lib/Module/Release/WebUpload/Mojo.pm
@@ -119,7 +119,7 @@ L<Module::Release>
 
 =head1 SOURCE AVAILABILITY
 
-This source is in Github:
+This source is in GitHub
 
 	https://github.com/briandfoy/module-release
 

--- a/script/release
+++ b/script/release
@@ -244,7 +244,7 @@ A string representing options to add to the command line.
 
 =head1 SOURCE AVAILABILITY
 
-This source is in Github as part of the Module::Release project:
+This source is in GitHub as part of the Module::Release project:
 
 	https://github.com/briandfoy/module-release
 


### PR DESCRIPTION
It turns out that the 'H' in 'GitHub' is supposed to be capitalised.
This change fixes all occurrences to use the style used by GitHub
itself.

I happened to notice this issue while spell checking the documentation.  Hope it's alright to make this change.