### PR TITLE
Fix typos in POD and comments

### DIFF
--- a/lib/Module/Release.pm
+++ b/lib/Module/Release.pm
@@ -363,7 +363,7 @@ sub mixin_loaded { exists $Loaded_mixins{ $_[1] } }
 
 =back
 
-=head2 Methods for configuation and settings
+=head2 Methods for configuration and settings
 
 =over 4
 
@@ -589,7 +589,7 @@ sub null_fh  {
 
 =item quiet
 
-Get the value of queit mode (true or false).
+Get the value of quiet mode (true or false).
 
 =item turn_quiet_on
 
@@ -1024,7 +1024,7 @@ sub check_manifest {
 
 =item manifest_name
 
-Return the name of the manifes file, probably F<MANIFEST>.
+Return the name of the manifest file, probably F<MANIFEST>.
 
 =item manifest
 

--- a/lib/Module/Release/FTP.pm
+++ b/lib/Module/Release/FTP.pm
@@ -124,7 +124,7 @@ sub ftp_class_name { 'Net::FTP' }
 
 =item get_ftp_object( HOSTNAME )
 
-Create and returnt the FTP object, based on the class name from
+Create and return the FTP object, based on the class name from
 C<ftp_class_name>. IT connects to HOSTNAME, but does not login.
 
 =cut

--- a/lib/Module/Release/Prereq.pm
+++ b/lib/Module/Release/Prereq.pm
@@ -18,7 +18,7 @@ Module::Release::Prereq - Check pre-requisites list in build file
 =head1 SYNOPSIS
 
 The release script automatically loads this module and checks your
-prerequisite declaration against what you actaully used in the
+prerequisite declaration against what you actually used in the
 tests.
 
 =head1 DESCRIPTION

--- a/lib/Module/Release/SVN.pm
+++ b/lib/Module/Release/SVN.pm
@@ -108,7 +108,7 @@ sub check_vcs {
 	if($question_count)
 		{
     	$self->_print "\nWARNING: Subversion is not up-to-date ($question_count files unknown); ",
-      "continue anwyay? [Ny] " ;
+      "continue anyway? [Ny] " ;
 		die "Exiting\n" unless <> =~ /^[yY]/;
 		}
 
@@ -178,7 +178,7 @@ sub vcs_tag {
 	# Make sure the top-level path exists
 	#
 	# Can't use $self->run() because of a bug where $fh isn't closed, which
-	# stops $? from being properly propogated.  Reported to brian d foy as
+	# stops $? from being properly propagated.  Reported to brian d foy as
 	# part of RT#6489
 	$self->run( "svn list $tag_url 2>&1" );
 	if( $? ) {


### PR DESCRIPTION
Just some typos I spotted by running a spell checker over the source files containing POD.