### PR TITLE
Remove unused variable '$got' in dist_version tests

### DIFF
--- a/t/dist_version.t
+++ b/t/dist_version.t
@@ -45,7 +45,6 @@ subtest 'formatting dev version' => sub {
 
 subtest 'formatting release version' => sub {
 	my $mock = bless { remote_file => 'Foo-3.45.tar.gz' }, $class;
-	my $got = $mock->dist_version;
 	is( $mock->dist_version, '3.45',
 		"Without development version it's fine"
 		);
@@ -53,7 +52,6 @@ subtest 'formatting release version' => sub {
 
 subtest 'formatting integer version' => sub {
 	my $mock = bless { remote_file => 'Foo-20160101.tar.gz' }, $class;
-	my $got = $mock->dist_version;
 	is( $mock->dist_version, '20160101',
 		"Single integer version extracts correct number"
 		);
@@ -61,7 +59,6 @@ subtest 'formatting integer version' => sub {
 
 subtest 'formatting three digit minor version' => sub {
 	my $mock = bless { remote_file => 'Foo-3.045.tar.gz' }, $class;
-	my $got = $mock->dist_version;
 	is( $mock->dist_version, '3.045',
 		"Without development version it's fine"
 		);


### PR DESCRIPTION
While reading the test code I noticed that the `dist_version` method was
being called directly in the test check and hence the temporary variable
wasn't needed and hence can be removed.