### PR TITLE
Check that version numbers can be more than 2dp

### DIFF
--- a/t/dist_version.t
+++ b/t/dist_version.t
@@ -41,6 +41,11 @@ subtest 'formatting dev version' => sub {
 		'Development version stays in there'
 		);
 
+	$mock = bless { remote_file => 'Foo-1.125_039.tar.gz' }, $class;
+	is(
+		$mock->dist_version, '1.125_039',
+		'Development version handles more than two decimal places'
+		);
 	};
 
 subtest 'formatting release version' => sub {
@@ -48,6 +53,11 @@ subtest 'formatting release version' => sub {
 	my $got = $mock->dist_version;
 	is( $mock->dist_version, '3.45',
 		"Without development version it's fine"
+		);
+
+	$mock = bless { remote_file => 'Foo-1.001.tar.gz' }, $class;
+	is( $mock->dist_version, '1.001',
+		"Three decimal places are retained in version number"
 		);
 	};
 


### PR DESCRIPTION
These tests check for the issue mentioned in GH #5, namely that version
numbers such as 1.001 should not be reduced to 1.01.

Unfortunately, it seems that the issue mentioned in #5 isn't an issue anymore.  Perhaps these changes are useful to document that, or perhaps I've missed something.  Either way, here's the code, hope it helps in some way!