### PR TITLE
Require App::CPANTS::Lint for kwalitee checks

### DIFF
--- a/lib/Module/Release/Kwalitee.pm
+++ b/lib/Module/Release/Kwalitee.pm
@@ -35,8 +35,10 @@ It looks in local_name to get the name of the distribution file.
 
 sub check_kwalitee
 	{
-	eval "require Module::CPANTS::Analyse; 1" or
-		$_[0]->_die( "You need Module::CPANTS::Analyse to check kwalitee" );
+	my $cpants_analyse = "Module::CPANTS::Analyse";
+	my $cpants_lint = "App::CPANTS::Lint";
+	eval "require $cpants_analyse; require $cpants_lint; 1" or
+		$_[0]->_die( "You need $cpants_analyse and $cpants_lint to check kwalitee" );
 
 	$_[0]->_print( "Checking kwalitee... " );
 


### PR DESCRIPTION
The cpants_lint.pl program has been extracted into a separate project
and hence one needs `App::CPANTS::Lint` in order that the kwalitee tests
in `Module::Release` can be run.  Here I've extracted the required
module names into variables to try and be more descriptive, but also to
reduce the length of the strings required in the `eval` and in the `die`
message.