### PR TITLE
Avoid echoing password to terminal

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -67,6 +67,7 @@ my %WriteMakefile = (
 		'ConfigReader::Simple'  => '0',
 		'IO::Null'              => '0',
 		'Mojolicious'           => '4.50',
+		'Term::ReadKey'         => '0',
 		'URI'                   => '0',
 		},
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -74,6 +74,7 @@ my %WriteMakefile = (
 		'Test::More'            => '1',
 		'Test::Output'          => '0',
 		'Test::Without::Module' => '0',
+                'File::Temp'            => '0',
 		},
 
 	'META_MERGE' => {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -74,7 +74,9 @@ my %WriteMakefile = (
 		'Test::More'            => '1',
 		'Test::Output'          => '0',
 		'Test::Without::Module' => '0',
+                'Capture::Tiny'         => '0',
                 'File::Temp'            => '0',
+                'Sub::Override'         => '0',
 		},
 
 	'META_MERGE' => {

--- a/lib/Module/Release.pm
+++ b/lib/Module/Release.pm
@@ -195,6 +195,7 @@ sub _set_defaults {
 			debug          => $ENV{RELEASE_DEBUG} || 0,
 			local_file     => undef,
 			remote_file    => undef,
+			input_fh       => *STDIN{IO},
 			output_fh      => *STDOUT{IO},
 			debug_fh       => *STDERR{IO},
 			null_fh        => IO::Null->new(),
@@ -558,6 +559,16 @@ sub reset_perls {
 	return $self->{perls}{$^X} = $];
 	}
 
+
+=item input_fh
+
+Return the value of input_fh.
+
+=cut
+
+sub input_fh {
+    return $_[0]->{input_fh};
+}
 
 =item output_fh
 
@@ -1291,7 +1302,7 @@ sub get_env_var {
 	return $pass if defined( $pass ) && length( $pass );
 
 	$self->_print( "$field is not set.  Enter it now: " );
-	$pass = <>;
+	$pass = $self->_slurp;
 	chomp $pass;
 
 	return $pass if defined( $pass ) && length( $pass );
@@ -1313,6 +1324,17 @@ output_fh to a null filehandle, output goes nowhere.
 =cut
 
 sub _print { print { $_[0]->output_fh } @_[1..$#_] }
+
+=item _slurp
+
+Read a line from whatever is in input_fh and return it.
+
+=cut
+
+sub _slurp {
+    my $fh = $_[0]->input_fh;
+    return <$fh>;
+}
 
 =item _dashes()
 

--- a/lib/Module/Release.pm
+++ b/lib/Module/Release.pm
@@ -1302,7 +1302,17 @@ sub get_env_var {
 	return $pass if defined( $pass ) && length( $pass );
 
 	$self->_print( "$field is not set.  Enter it now: " );
-	$pass = $self->_slurp;
+	if ($field eq 'CPAN_PASS') {
+		# don't echo passwords to the screen
+		require Term::ReadKey;
+		local $| = 1;
+		Term::ReadKey::ReadMode('noecho');
+		$pass = $self->_slurp;
+		Term::ReadKey::ReadMode('restore');
+	}
+	else {
+		$pass = $self->_slurp;
+	}
 	chomp $pass;
 
 	return $pass if defined( $pass ) && length( $pass );

--- a/t/get_env_var.t
+++ b/t/get_env_var.t
@@ -1,0 +1,58 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 8;
+use Sub::Override;
+use Capture::Tiny qw( capture );
+
+use Module::Release;
+
+BEGIN {
+	use File::Spec;
+	my $file = File::Spec->catfile( qw(. t lib setup_common.pl) );
+	require $file;
+	}
+
+my $release = Module::Release->new;
+$release->{'preset_field'} = 'preset';
+is( $release->get_env_var('PRESET_FIELD'),
+    'preset', 'Preset field value returned' );
+
+$ENV{'MOO'} = 'baa';
+is( $release->get_env_var('MOO'),
+    'baa', 'Preset environment variable value returned' );
+
+{
+    my $terminal_input =
+      Sub::Override->new( 'Module::Release::_slurp' => sub { "baa\n" } );
+    $ENV{'MOO'} = '';
+    my ( $stdout, $stderr, @result ) = capture { $release->get_env_var('MOO') };
+    is(
+        $stdout,
+        'MOO is not set.  Enter it now: ',
+        'Empty environment variable prompts for value'
+    );
+    is( $result[0], 'baa', 'Variable read from input' );
+}
+
+{
+    my $terminal_input =
+      Sub::Override->new( 'Module::Release::_slurp' => sub { "\n" } );
+    $ENV{'MOO'} = undef;
+    $release->turn_debug_on;
+    my ( $stdout, $stderr, @result ) = capture { $release->get_env_var('MOO') };
+    is(
+        $stdout,
+        'MOO is not set.  Enter it now: ',
+        'Undef environment variable prompts for value'
+    );
+    is(
+        $stderr,
+        "MOO not supplied.  Aborting...\n",
+        "Error message about missing variable shown in debug mode"
+    );
+}
+
+# vim: expandtab shiftwidth=4

--- a/t/get_env_var.t
+++ b/t/get_env_var.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 8;
+use Test::More tests => 10;
 use Sub::Override;
 use Capture::Tiny qw( capture );
 
@@ -53,6 +53,19 @@ is( $release->get_env_var('MOO'),
         "MOO not supplied.  Aborting...\n",
         "Error message about missing variable shown in debug mode"
     );
+}
+
+{
+    my $terminal_input =
+      Sub::Override->new( 'Module::Release::_slurp' => sub { "s3cr3t\n" } );
+    $ENV{'CPAN_PASS'} = undef;
+    my ( $stdout, $stderr, @result ) = capture { $release->get_env_var('CPAN_PASS') };
+    is(
+        $stdout,
+        'CPAN_PASS is not set.  Enter it now: ',
+        'Undef CPAN_PASS variable prompts for value'
+    );
+    is( $result[0], 's3cr3t', 'Variable password from input' );
 }
 
 # vim: expandtab shiftwidth=4

--- a/t/input.t
+++ b/t/input.t
@@ -1,0 +1,32 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 3;
+use File::Temp qw(:seekable);
+
+use Module::Release;
+
+BEGIN {
+	use File::Spec;
+	my $file = File::Spec->catfile( qw(. t lib setup_common.pl) );
+	require $file;
+	}
+
+my $release = Module::Release->new;
+my $temp_fh = File::Temp->new;
+$temp_fh->write("to be or not to be\n");
+$temp_fh->flush();
+$temp_fh->seek( 0, SEEK_SET );
+
+$release->{input_fh} = $temp_fh;
+my $input = $release->_slurp;
+
+is(
+    $input,
+    "to be or not to be\n",
+    '_slurp returns content from input file handle'
+);
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
I used `Module::Release` to automate the release of one of my modules and was a bit shocked to find my PAUSE password being echoed to the terminal.  Hence, I tested and refactored the `get_env_var()` method so that when one is asked to set the `CPAN_PASS` variable, the password isn't echoed to the screen.  The code for this I adapted from `CPAN::Uploader`.  If you have any questions or comments, or want to discuss how I've implemented this, please feel free!  If you want to have anything changed I can update the PR and resubmit as necessary.