### PR TITLE
Return release date string via get_release_date() method

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -65,6 +65,7 @@ my %WriteMakefile = (
 	'PREREQ_PM'    => {
 		'CACertOrg::CA'         => '0',
 		'ConfigReader::Simple'  => '0',
+		'DateTime'              => '0',
 		'IO::Null'              => '0',
 		'Mojolicious'           => '4.50',
 		'URI'                   => '0',

--- a/lib/Module/Release.pm
+++ b/lib/Module/Release.pm
@@ -30,6 +30,7 @@ use Carp qw(carp croak);
 use File::Basename qw(dirname);
 use File::Spec;
 use Scalar::Util qw(blessed);
+use DateTime;
 
 my %Loaded_mixins = ( );
 
@@ -1223,6 +1224,21 @@ sub get_changes {
 		}
 
 	return $data;
+	}
+
+=item get_release_date()
+
+Return a string representing the current date and time (in UTC) in the
+L<CPAN::Changes::Spec> format so that it can be added directly to the
+Changes file.
+
+=cut
+
+sub get_release_date {
+	my $self = shift;
+	my $dt = DateTime->now(time_zone => 'UTC');
+
+	return $dt->datetime . 'Z';
 	}
 
 =item run

--- a/script/release
+++ b/script/release
@@ -500,15 +500,7 @@ unless( $release->debug or $opts{C} ) {
 	die "Changes file does not exist!\n" unless -e $changes;
 
 	$release->_print( "\n", "-" x 73, "\n", "Enter Changes section\n\n> " );
-
-	my( $year, $month, $day, $hour, $minute, $second )
-		= (gmtime)[5,4,3,2,1,0];
-	$year += 1900;
-	$month += 1;
-	my $datetime = sprintf "%4d-%02d-%02dT%02d:%02d:%02dZ",
-		$year, $month, $day, $hour, $minute, $second;
-
-	my $str = $Version . ' ' . $datetime . "\n";
+	my $str = $Version . ' ' . $release->get_release_date . "\n";
 
 	while( <STDIN> ) {
 		$_ =~ s/\A \s* (\*|-)? \s*/- /; # Make bullets (-)

--- a/t/dates.t
+++ b/t/dates.t
@@ -1,0 +1,32 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 4;
+
+use Module::Release;
+
+BEGIN {
+    use File::Spec;
+    my $file = File::Spec->catfile(qw(. t lib setup_common.pl));
+    require $file;
+}
+
+my $release = Module::Release->new;
+
+like(
+    $release->get_release_date,
+    qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/,
+    "Returns datetime in UTC as a string in required format"
+);
+
+{
+    no warnings 'redefine';
+    local *DateTime::datetime = sub { '2017-09-02T10:05:49' };
+    is( $release->get_release_date,
+        '2017-09-02T10:05:49Z',
+        "Returns known datetime as a string in required format" );
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
The release date given in the Changes file should conform to the
format defined in CPAN::Changes::Spec.  Although the code in the
`release` script already conformed to this spec, it's nicer to have the
functionality wrapped in a method.  These changes add the new
`get_release_date()` method as well as tests for it, and replace the
existing code in the `release` script with the new method call.