### PR TITLE
Add tests for get_changes() method

### DIFF
--- a/t/changes.t
+++ b/t/changes.t
@@ -1,0 +1,48 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 5;
+
+use Module::Release;
+
+BEGIN {
+    use File::Spec;
+    my $file = File::Spec->catfile(qw(. t lib setup_common.pl));
+    require $file;
+}
+
+my $release = Module::Release->new;
+
+# due to the setup code above, we're in a directory without a 'Changes'
+# file, hence:
+is( $release->get_changes, '',
+    'Empty string returned with nonexistent Changes file' );
+
+{
+    my $changes = <<'EOF';
+Revision history for Perl module My::Temp::Test::Module
+
+0.1 1900-01-01T00:00:00Z
+    * initial release
+EOF
+    open my $fh, ">", "Changes" or die "$!";
+    print $fh $changes;
+    close $fh;
+
+    like(
+        $release->get_changes,
+        qr/Revision history for Perl module/m,
+        'Changes text includes title text'
+    );
+    is(
+        $release->get_changes,
+        "Revision history for Perl module My::Temp::Test::Module\n\n",
+        'Changes includes title and text up to first non-w/s-beginning line'
+    );
+
+    unlink "Changes" or die "$!";
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
These tests attempt to document the current behaviour of the
`get_changes()` method.

Interestingly enough, this PR probably creates more questions than it tries to answer.  My goal was to increase the code coverage, however in creating the tests I noticed that the implementation of the `get_changes()` method doesn't really match the documentation for the method in that it doesn't really seem to parse the whole `Changes` file; it seems to just read the title/header text at the top and return that.  Furthermore, the `get_changes()` method isn't used anywhere in the dist; not even in the `release` script.  It also doesn't read and parse the `Changes` file for the dist itself, so I'm guessing that something changed in the in past to make the method no longer relevant.

I would guess that you don't want to delete the method since there are possibly clients subclassing it in the manner described in the docs; hence removing it could cause breakage of downstream code, which would be a bad thing.  Perhaps it would be best to update method to actually parse the `Changes` file into a data structure so that the code in `release` can simply insert the new changes into the relevant position and then write out the new version?  One could also accept an optional argument to the method which specifies an alternative `Changes` file if the user so wishes (this could also make testing a bit easier).  What do you think?  Is it worth the effort to make such a change?