### PR TITLE
Remove the get_readme() method

### DIFF
--- a/lib/Module/Release.pm
+++ b/lib/Module/Release.pm
@@ -1188,23 +1188,6 @@ sub check_for_passwords {
 	$_[0]->_debug( "CPAN pass is " . $_[0]->config->cpan_pass . "\n" );
 	}
 
-=item get_readme()
-
-Read and parse the F<README> file.  This is pretty specific, so
-you may well want to overload it.
-
-=cut
-
-sub get_readme {
-	open my $fh, '<', 'README' or return '';
-	my $data = do {
-		local $/;
-		<$fh>;
-		};
-
-	return $data;
-	}
-
 =item get_changes()
 
 Read and parse the F<Changes> file.  This is pretty specific, so


### PR DESCRIPTION
It's not being used anywhere anymore.  It seems that it used to be used
as part of the release process to SourceForge, however that no longer
seems to be relevant, hence the code is superfluous and can go.