### PR TITLE
Show list of contributors since previous release

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -67,13 +67,16 @@ my %WriteMakefile = (
 		'ConfigReader::Simple'  => '0',
 		'IO::Null'              => '0',
 		'Mojolicious'           => '4.50',
+		'Try::Tiny'             => '0',
 		'URI'                   => '0',
 		},
 
 	'TEST_REQUIRES' => {
+		'Test::Exception'       => '0',
 		'Test::More'            => '1',
 		'Test::Output'          => '0',
 		'Test::Without::Module' => '0',
+		'Capture::Tiny'         => '0',
 		},
 
 	'META_MERGE' => {

--- a/lib/Module/Release.pm
+++ b/lib/Module/Release.pm
@@ -30,6 +30,7 @@ use Carp qw(carp croak);
 use File::Basename qw(dirname);
 use File::Spec;
 use Scalar::Util qw(blessed);
+use Try::Tiny;
 
 my %Loaded_mixins = ( );
 
@@ -1223,6 +1224,37 @@ sub get_changes {
 		}
 
 	return $data;
+	}
+
+=item show_recent_contributors()
+
+Show recent contributors before creating/extending Changes.
+
+This output relies upon the method C<get_recent_contributors()> having been
+implemented in the relevant mixin for your version control system.
+
+=cut
+
+sub show_recent_contributors {
+	my $self = shift;
+        my @contributors = try {
+            $self->get_recent_contributors();
+        }
+        catch {
+            return ();
+        };
+	$self->_print("Contributors since last release:\n") if @contributors;
+	$self->_print( "\t", $_, "\n" ) for (@contributors);
+	}
+
+=item get_recent_contributors()
+
+Return a list of contributors since last release.
+
+=cut
+
+sub get_recent_contributors {
+	$_[0]->_die( "get_recent_contributors must be implemented in a mixin class" );
 	}
 
 =item run

--- a/script/release
+++ b/script/release
@@ -494,6 +494,8 @@ if( $opts{t} ) {
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # CPAN::Spec::Changes
 unless( $release->debug or $opts{C} ) {
+	$release->show_recent_contributors;
+
 	my $changes = "Changes";
 	my $bak     = $changes . ".bak";
 

--- a/t/contributors.t
+++ b/t/contributors.t
@@ -1,0 +1,57 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 6;
+use Test::Exception;
+use Capture::Tiny qw( capture_stdout );
+
+use Module::Release;
+
+BEGIN {
+    use File::Spec;
+    my $file = File::Spec->catfile(qw(. t lib setup_common.pl));
+    require $file;
+}
+
+my $release = Module::Release->new;
+
+dies_ok(
+    sub { $release->get_recent_contributors },
+    "Non-subclassed get_recent_contributors dies"
+);
+
+{
+    no warnings 'redefine';
+    local *Module::Release::get_recent_contributors =
+      sub { return ('Joe Bloggs <joe@bloggs.com>') };
+    is(
+        $release->get_recent_contributors,
+        ('Joe Bloggs <joe@bloggs.com>'),
+        "Can get defined recent contributor list"
+    );
+}
+
+{
+    my $output = capture_stdout { $release->show_recent_contributors };
+    is( $output, '',
+        "No contributor output without subclassed get_recent_contributors" );
+}
+
+{
+    no warnings 'redefine';
+    local *Module::Release::get_recent_contributors =
+      sub { ( 'Jane Smith <jane@smith.com>', 'Joe Bloggs <joe@bloggs.com>' ) };
+
+    my $output = capture_stdout { $release->show_recent_contributors };
+    my $expected_output = <<'EOF';
+Contributors since last release:
+	Jane Smith <jane@smith.com>
+	Joe Bloggs <joe@bloggs.com>
+EOF
+    is( $output, $expected_output,
+        "Contributors since last release are shown" );
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
These changes implement two routines which fulfill the desired feature
mentioned in #11: one to print the list of recent contributors
(`show_recent_contributors()`) and one to obtain the list of recent
contributors from the relevant version control system
(`get_recent_contributors()`).  The `get_recent_contributors()` method
is only a stub and needs to be overridden by the appropriate mixin for
the given version control system.  A concrete implementation of this
method will be submitted in a separate PR to the `Module::Release::Git`
repository.