### PR TITLE
Skip ->dist if $skip_dist

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -52,7 +52,7 @@ my %WriteMakefile = (
 	'LICENSE'       => 'artistic_2',
 	'AUTHOR'        => 'brian d foy <bdfoy@cpan.org>',
 
-	'EXE_FILES'    =>  [ 'script/release' ],
+	'EXE_FILES'    =>  [ 'script/release', 'script/release-test' ],
 
 	'CONFIGURE_REQUIRES' => {
 		'ExtUtils::MakeMaker'   => '6.64',
@@ -98,7 +98,8 @@ my %WriteMakefile = (
 		},
 
 	'MAN1PODS'     => {
-		'script/release' => '$(INST_MAN1DIR)/release.$(MAN1EXT)',
+		'script/release'      => '$(INST_MAN1DIR)/release.$(MAN1EXT)',
+		'script/release-test' => '$(INST_MAN1DIR)/release-test.$(MAN1EXT)',
 		},
 
 	'clean' => { FILES => "$dist-*" },

--- a/lib/Module/Release.pm
+++ b/lib/Module/Release.pm
@@ -51,6 +51,9 @@ to the right places.
 The included C<release> script is a good starting place. Don't be afraid to
 edit it for your own purposes.
 
+The included C<release-test> script is a variation on C<release> aimed at
+pre-release testing against multiple perl versions.
+
 =head2 Configuration
 
 C<Module::Release> looks at several sources for configuration information.

--- a/script/release
+++ b/script/release
@@ -557,7 +557,7 @@ $release->_debug( "Will use HARNESS_OPTIONS '$ENV{HARNESS_OPTIONS}' during tests
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Check that this is a version later than the one of CPAN
-unless( $opts{V} // $skip_dist || $release->config->skip_cpan_version_check ) {
+unless( $opts{V} // $release->config->skip_cpan_version_check ) {
 	$release->_print("============ Checking CPAN versions\n");
 	$release->load_mixin( 'Module::Release::MetaCPAN' );
 
@@ -595,7 +595,7 @@ unless( $opts{k} // $release->config->skip_kwalitee  ) {
 	$release->clean;
 	$release->build_makefile;
 	$release->make;
-	$release->dist unless $skip_dist;
+	$release->dist;
 	$release->check_kwalitee;
 	}
 else {
@@ -684,7 +684,7 @@ unless( $opts{T} // $release->config->skip_tests ) {
 if( $opts{t} // $release->config->dry_run ) {
 	$release->_print("============ Cleaning up\n");
 	$release->_print( "This is a dry run, so stopping. Cleaning up.\n" );
-	eval { $release->distclean };
+	$release->distclean;
 	unlink glob( '*.tar *.tgz *.tar.gz *.tar.bz *.tar.bz2 *.tbz *.zip' );
 	exit;
 	}
@@ -763,7 +763,7 @@ $release->clean;
 $release->touch_all_in_manifest;
 $release->build_makefile;
 $release->make;
-$release->dist unless $skip_dist;
+$release->dist;
 
 $release->check_for_passwords;
 

--- a/script/release
+++ b/script/release
@@ -557,7 +557,7 @@ $release->_debug( "Will use HARNESS_OPTIONS '$ENV{HARNESS_OPTIONS}' during tests
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Check that this is a version later than the one of CPAN
-unless( $opts{V} // $release->config->skip_cpan_version_check ) {
+unless( $opts{V} // $skip_dist || $release->config->skip_cpan_version_check ) {
 	$release->_print("============ Checking CPAN versions\n");
 	$release->load_mixin( 'Module::Release::MetaCPAN' );
 
@@ -595,7 +595,7 @@ unless( $opts{k} // $release->config->skip_kwalitee  ) {
 	$release->clean;
 	$release->build_makefile;
 	$release->make;
-	$release->dist;
+	$release->dist unless $skip_dist;
 	$release->check_kwalitee;
 	}
 else {
@@ -684,7 +684,7 @@ unless( $opts{T} // $release->config->skip_tests ) {
 if( $opts{t} // $release->config->dry_run ) {
 	$release->_print("============ Cleaning up\n");
 	$release->_print( "This is a dry run, so stopping. Cleaning up.\n" );
-	$release->distclean;
+	eval { $release->distclean };
 	unlink glob( '*.tar *.tgz *.tar.gz *.tar.bz *.tar.bz2 *.tbz *.zip' );
 	exit;
 	}
@@ -763,7 +763,7 @@ $release->clean;
 $release->touch_all_in_manifest;
 $release->build_makefile;
 $release->make;
-$release->dist;
+$release->dist unless $skip_dist;
 
 $release->check_for_passwords;
 

--- a/script/release-test
+++ b/script/release-test
@@ -6,7 +6,7 @@
 use 5.014002;
 use warnings;
 
-our $VERSION = "0.01 - 20230804";
+our $VERSION = "0.02 - 20230805";
 our $CMD = $0 =~ s{.*/}{}r;
 
 sub usage {
@@ -80,11 +80,7 @@ unless ($opt_r) {
 	}
     }
 
-$release->load_mixin ("Module::Release::Prereq");
-
-my $skip_prereqs = 1;
-my $skip_dist    = 1;
-my $required     = $release->config->required // "";
+my $required = $release->config->required // "";
 
 $ENV{AUTOMATED_TESTING} = 1;
 
@@ -116,6 +112,7 @@ PERL: foreach my $perl (@perls) {
     $release->clean;
 
     foreach my $mod (grep m/\S/ => split m/\s*,\s*/ => $required) {
+	$mod =~ m/^\w+(::\w+)*$/ or next;
 	system "$perl -M$mod -e1 >/dev/null 2>&1";
 	if ($?) {
 	    warn "Prereq $mod not available\n";

--- a/script/release-test
+++ b/script/release-test
@@ -1,0 +1,195 @@
+#!/pro/bin/perl
+
+# A modified version of Module::Reales's "release", aimed at testing the
+# current distribution against all available perls (given .releaserc)
+
+use 5.014002;
+use warnings;
+
+our $VERSION = "0.01 - 20230804";
+our $CMD = $0 =~ s{.*/}{}r;
+
+sub usage {
+    my $err = shift and select STDERR;
+    say "usage: $CMD [-r] [-d] [-jN] [local [remote]]";
+    say "       -r  --skip-repo   Skip repository check";
+    say "       -d  --skip-debug  Print extra debugging information";
+    say "       -jN --jobs=N      Enable parallel tests";
+    exit $err;
+    } # usage
+
+my %opts = map { $_ => 1 } qw( t  a k m p C D );
+use Getopt::Long qw(:config bundling);
+GetOptions (
+    "help|?"		=> sub { usage (0); },
+    "V|version"		=> sub { say "$CMD [$VERSION]"; exit 0; },
+
+    "r|skip-repo!"	=> \my $opt_r,
+    "d|skip-debug!"	=> \$opts{d},
+    "j|jobs:0"		=> \$opts{j},
+
+    "v|verbose:1"	=> \(my $opt_v = 0),
+    ) or usage (1);
+
+use Module::Release 2.131;
+
+my $class = "Module::Release";
+
+# ALL CODE BELOW IS DIRECTLY COPIED FROM release
+# WHERE IRRELAVANT CODE FOR THIS SCRIPTS PURPOSE
+# HAS BEEN REMOVED. Style/layout changed though.
+
+# get the release object
+my %params;
+@ARGV and $params{local} = shift;
+
+if (@ARGV) {
+    $params{remote} = shift;
+    }
+elsif ($params{local}) {
+    $params{remote} = $params{local};
+    }
+$opts{d} and $params{debug} = 1;
+
+my $release = $class->new (%params);
+$release->_debug ("$CMD $VERSION, using $class " . $class->VERSION . "\n");
+
+# load whatever will handle source control
+unless ($opt_r) {
+    my @vcs = (
+	[ ".git"       => "Module::Release::Git" ],
+	[ ".gitignore" => "Module::Release::Git" ],
+	[ ".svn"       => "Module::Release::SVN" ],
+	[ "CVS"        => "Module::Release::CVS" ],
+	);
+    foreach my $vcs ( @vcs ) {
+	-e $vcs->[0] or next;
+	my $module = $vcs->[1];
+	$release->_debug ("I see an $vcs->[0] directory, so I'm loading $module\n");
+	$release->load_mixin ($module);
+	$@ and $release->_die ("Could not load $module: $@\n");
+	last;
+	}
+
+    if ($release->can ("is_allowed_branch")) {
+	$release->_print ("============ Checking for allowed branch\n");
+	my $branch = $release->vcs_branch;
+	$release->is_allowed_branch or
+	    $release->_die ("Configuration blocks release from branch <$branch>\n");
+	$release->_print ("Branch <$branch> is allowed to release\n");
+	}
+    }
+
+$release->load_mixin ("Module::Release::Prereq");
+
+my $skip_prereqs = 1;
+my $skip_dist    = 1;
+my $required     = $release->config->required // "";
+
+$ENV{AUTOMATED_TESTING} = 1;
+
+my $test_jobs = $opts{j} // $release->config->test_jobs;
+if (defined $test_jobs) {
+    $test_jobs ||= eval {
+	require System::Info;
+	System::Info->new->get_core_count;
+	} || 9;
+    $ENV{HARNESS_OPTIONS} = join ":" => grep { length }
+	(split m/:/ => ($ENV{HARNESS_OPTIONS} // "")),
+	"j$test_jobs";
+    $release->_debug ("Will use HARNESS_OPTIONS '$ENV{HARNESS_OPTIONS}' during tests\n");
+    }
+
+unless ($opt_r) {
+    $release->_print ("============ Checking source repository\n");
+    $release->check_vcs;
+    }
+
+# Test with a bunch of perls
+my $old_perl = $release->get_perl;
+my @perls    = $release->perls;
+my ($n, $N)  = (1, scalar @perls);
+PERL: foreach my $perl (@perls) {
+    $release->_print ("============ Testing with $perl (", $n++, "/$N)\n");
+    $release->set_perl ($perl) or next;
+
+    $release->clean;
+
+    foreach my $mod (grep m/\S/ => split m/\s*,\s*/ => $required) {
+	system "$perl -M$mod -e1 >/dev/null 2>&1";
+	if ($?) {
+	    warn "Prereq $mod not available\n";
+	    next PERL;
+	    }
+	}
+
+    $release->build_makefile;
+    $release->make;
+    $release->test;
+    }
+$release->set_perl ($old_perl);
+
+$release->_print ("============ Cleaning up\n");
+$release->distclean;
+unlink glob "*.tar *.tgz *.tar.gz *.tar.bz *.tar.bz2 *.tbz *.zip";
+
+$release->_print ("============ DONE!\n");
+
+__END__
+
+=encoding utf-8
+
+=head1 NAME
+
+release-test - test your dist against all available perl versions
+
+=head1 SYNOPSIS
+
+  release-test
+
+=head1 DESCRIPTION
+
+This is a stripped-down version of Module::Release' C<release> tool with default
+options aimed at testing the current distribution against all perl versions as
+givern in F<.releaserc>. It should be somewhat equivalent to
+
+ $ release -t -a -k -D -m -p -C
+
+or with these options in C<.releaserc>:
+
+ automated_testing 1
+ skip_kwalitee 1
+ skip_manifest 1
+ skip_prereqs 1
+ skip_changes 1
+ skip_dist 1
+ ignore_untracked 1
+ allow_glob_in_perls 1
+
+All other options in F<.releaserc> are allowed too.
+
+=head1 REFERENCE
+
+Read the documentation for L<release>
+
+=head1 SOURCE AVAILABILITY
+
+This source is in GitHub as part of the Module::Release project:
+
+	https://github.com/briandfoy/module-release
+
+=head1 SEE ALSO
+
+L<Module::Realease>
+
+=head1 AUTHOR
+
+H.Merijn Brand C<< <hmbrand@cpan.org> >>
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2023-2023, H.Merijn Brand & brian d foy. All rights reserved.
+
+You may use this software under the same terms as Perl itself.
+
+=cut


### PR DESCRIPTION
This includes skipping `cpan_version_check`, as it depends on running `dist`

When running `release -t` on 400 versions of perl, dist checks and mere annoying and certainly not helpful